### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,9 @@ jobs:
         - os: ubuntu-latest
           python: '3.10'
           toxenv: py310
+        - os: ubuntu-latest
+          python: '3.11'
+          toxenv: py311
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py37, py38, py39, py310, pre-commit
+envlist = py37, py38, py39, py310, py311, pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt
 commands =
+    # dill>=0.3.6 required for Python 3.11 but FuncX 1.0.8 pins it to 0.3.5.1
+    pip install -U dill==0.3.6
     coverage erase
     coverage run -m pytest {posargs}
     coverage combine --quiet


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Support Python 3.11. Note FuncX 1.0.8 doesn't technically support Python 3.11 because it pins dill to an old version, but manually updating dill will work.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [x] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
