### PR TITLE
Add stream scaling benchmark

### DIFF
--- a/docs/stream-scaling.md
+++ b/docs/stream-scaling.md
@@ -1,0 +1,89 @@
+# Stream Scaling
+
+This benchmark simulates stream processing workflow composed of one
+data generator, one data dispatcher, and a set of data compute workers.
+The data generator publishes data to the stream which is then consumed
+by the dispatcher. The dispatcher launches compute tasks (simulated with
+sleeps) for each data item across the workers.
+
+There a two streaming methods: "default" uses a Redis pub/sub or Kafka
+broker to stream data directly from the generator to the dispatcher and
+"proxy" which streams data via proxies. In the "proxy" case, only metadata
+is sent via the Redis pub/sub or Kafka broker and bulk data is transmitted
+via the specified ProxyStore connector. This enables the dispatcher to
+process the stream without resolving data; data communication occurs directly
+between the generator and the worker computing on the data.
+
+## Setup
+
+1. Create a new virtual environment.
+   ```bash
+   $ python -m venv venv
+   $ . venv/bin/activate
+   ```
+2. Install the `psbench` package (must be done from root of repository).
+   ```bash
+   $ pip install .
+   ```
+3. Start a Redis server (or Kafka if preferred).
+   ```
+   $ redis-server --save "" --appendonly no
+   ```
+
+## Benchmark
+
+The benchmark can be configured using CLI parameters. The full list of options
+can be found using `--help`.
+
+```bash
+python -m psbench.run.stream_scaling \
+    --executor parsl --parsl-executor htex-local --parsl-max-workers 4 \
+    --stream-method default proxy \
+    --data-size-bytes 100000 1000000 10000000 \
+    --task-count 16 \
+    --task-sleep 1.0 \
+    --ps-connector redis --ps-host localhost --ps-port 6379 \
+    --stream redis --stream-servers localhost:6379
+```
+
+This configurations uses a local Redis server for both message streaming and
+bulk data storage with ProxyStore, and tasks are executed using a Parsl
+HighThroughputExecutor with 4 workers.
+
+Six experiments will be performed: three for each of the specified data sizes
+and then twice for each stream method ("default" or "proxy"). In the
+experiment, the data generator will generate random bytes with size
+`data_size_bytes` with an interval of `task-sleep / (workers - 1)`.
+Note there are `workers - 1` compute workers because one worker is designated
+the generator. The dispatcher will consume data and dispatch compute tasks
+as quickly as possible, with each compute task resolving the input data and
+then sleeping for `task-sleep` seconds.
+
+**Note:** Redis pub/sub places a limit on the maximum data rate of clients
+so large data sizes or fast data generation rates may crash Redis or raise
+"Serialized object exceeds buffer threshold of 1048576 bytes, this could cause
+overflows" warning. You may need to adjust the Redis server configuration
+according to your benchmark parameters.
+
+### Executors
+
+The task executor can be changed with CLI options. Some examples include:
+
+* Globus Compute:
+  ```bash
+  --executor globus --globus-compute-endpoint <UUID>
+  ```
+* Parsl `ThreadPoolExecutor`:
+  ```bash
+  --executor parsl --parsl-executor thread --parsl-max-workers 4
+  ```
+* Parsl Local `HighThroughputExecutor`:
+  ```bash
+  --executor parsl --parsl-executor htex-local --parsl-max-workers 4
+  ```
+
+### ProxyStore
+
+The ProxyStore connector can be configured using the `--ps-connector`
+option. Some choices for `--ps-connector` will mark additional CLI options
+as required.

--- a/psbench/benchmarks/protocol.py
+++ b/psbench/benchmarks/protocol.py
@@ -5,6 +5,7 @@ from types import TracebackType
 from typing import Any
 from typing import Protocol
 from typing import runtime_checkable
+from typing import Sequence
 from typing import TypeVar
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
@@ -38,5 +39,5 @@ class Benchmark(Protocol[RunConfigT, RunResultT]):
     def config(self) -> dict[str, Any]:
         ...
 
-    def run(self, config: RunConfigT) -> RunResultT:
+    def run(self, config: RunConfigT) -> RunResultT | Sequence[RunResultT]:
         ...

--- a/psbench/benchmarks/stream_scaling/config.py
+++ b/psbench/benchmarks/stream_scaling/config.py
@@ -15,9 +15,8 @@ from pydantic import BaseModel
 
 class RunConfig(BaseModel):
     data_size_bytes: int
-    producer_sleep: float
     task_count: int
-    task_sleep: int
+    task_sleep: float
 
 
 class RunResult(BaseModel):
@@ -25,17 +24,16 @@ class RunResult(BaseModel):
     connector: str
     stream: str
     data_size_bytes: int
-    producer_sleep: float
     task_count: int
     task_sleep: float
     workers: int
-    task_submitted_timestamp: float
-    task_received_timestamp: float
+    completed_tasks: int
+    start_submit_tasks_timestamp: float
+    end_tasks_done_timestamp: float
 
 
 class BenchmarkMatrix(BaseModel):
     data_size_bytes: List[int]  # noqa: UP006
-    producer_sleep: float
     task_count: int
     task_sleep: int
 
@@ -49,13 +47,6 @@ class BenchmarkMatrix(BaseModel):
             required=True,
             type=int,
             help='Size of stream data objects in bytes',
-        )
-        group.add_argument(
-            '--producer-sleep',
-            metavar='SECONDS',
-            required=True,
-            type=float,
-            help='Sleep time between producing new stream items',
         )
         group.add_argument(
             '--task-count',
@@ -76,7 +67,6 @@ class BenchmarkMatrix(BaseModel):
     def from_args(cls, **kwargs: Any) -> Self:
         return cls(
             data_size_bytes=kwargs['data_size_bytes'],
-            producer_sleep=kwargs['producer_sleep'],
             task_count=kwargs['task_count'],
             task_sleep=kwargs['task_sleep'],
         )
@@ -85,7 +75,6 @@ class BenchmarkMatrix(BaseModel):
         return tuple(
             RunConfig(
                 data_size_bytes=size,
-                producer_sleep=self.producer_sleep,
                 task_count=self.task_count,
                 task_sleep=self.task_sleep,
             )

--- a/psbench/benchmarks/stream_scaling/generator.py
+++ b/psbench/benchmarks/stream_scaling/generator.py
@@ -9,6 +9,7 @@ from proxystore.stream.interface import StreamProducer
 
 from psbench.config.stream import StreamConfig
 from psbench.utils import randbytes
+from psbench.utils import wait_until
 
 
 def generate_data(
@@ -23,6 +24,7 @@ def generate_data(
     sent_items = 0
 
     while sent_items < max_items:
+        interval_end = time.time() + interval
         if stop_generator.done():
             break
 
@@ -30,7 +32,7 @@ def generate_data(
         producer.send(topic, data, evict=True)
         sent_items += 1
 
-        time.sleep(interval)
+        wait_until(interval_end)
 
     producer.close_topics(topic)
 

--- a/psbench/benchmarks/stream_scaling/generator.py
+++ b/psbench/benchmarks/stream_scaling/generator.py
@@ -17,7 +17,7 @@ def generate_data(
     *,
     item_size_bytes: int,
     max_items: int,
-    sleep: float,
+    interval: float,
     topic: str,
 ) -> None:
     sent_items = 0
@@ -30,7 +30,7 @@ def generate_data(
         producer.send(topic, data, evict=True)
         sent_items += 1
 
-        time.sleep(sleep)
+        time.sleep(interval)
 
     producer.close_topics(topic)
 
@@ -42,7 +42,7 @@ def generator_task(
     *,
     item_size_bytes: int,
     max_items: int,
-    sleep: float,
+    interval: float,
     topic: str,
 ) -> None:
     store: Store[Any] = Store.from_config(store_config)
@@ -54,6 +54,6 @@ def generator_task(
             stop_generator,
             item_size_bytes=item_size_bytes,
             max_items=max_items,
-            sleep=sleep,
+            interval=interval,
             topic=topic,
         )

--- a/psbench/benchmarks/stream_scaling/main.py
+++ b/psbench/benchmarks/stream_scaling/main.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import collections
 import contextlib
+import logging
 import sys
+import time
 from types import TracebackType
 from typing import Any
 
@@ -11,11 +14,23 @@ else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
 from proxystore.store.base import Store
+from proxystore.store.future import Future
+from proxystore.stream.interface import StreamConsumer
 
 from psbench.benchmarks.stream_scaling.config import RunConfig
 from psbench.benchmarks.stream_scaling.config import RunResult
+from psbench.benchmarks.stream_scaling.generator import generator_task
 from psbench.config import StreamConfig
 from psbench.executor.protocol import Executor
+from psbench.logging import TESTING_LOG_LEVEL
+
+logger = logging.getLogger('stream-scaling')
+
+
+def compute_task(data: bytes, sleep: float) -> None:
+    # Resolve data if necessary
+    assert isinstance(data, bytes)
+    time.sleep(sleep)
 
 
 class Benchmark:
@@ -25,10 +40,12 @@ class Benchmark:
 
     def __init__(
         self,
+        consumer: StreamConsumer[bytes],
         executor: Executor,
         store: Store[Any],
         stream_config: StreamConfig,
     ) -> None:
+        self.consumer = consumer
         self.executor = executor
         self.store = store
         self.stream_config = stream_config
@@ -43,6 +60,7 @@ class Benchmark:
     def __enter__(self) -> Self:
         # https://stackoverflow.com/a/39172487
         with contextlib.ExitStack() as stack:
+            stack.enter_context(self.consumer)
             stack.enter_context(self.executor)
             stack.enter_context(self.store)
             self._stack = stack.pop_all()
@@ -60,20 +78,95 @@ class Benchmark:
         return {
             'executor': self.executor.__class__.__name__,
             'connector': self.store.connector.__class__.__name__,
-            'stream-broker': self.stream_config.kind,
+            'subscriber': self.consumer._subscriber.__class__.__name__,
+            'stream-config': self.stream_config,
         }
 
     def run(self, config: RunConfig) -> RunResult:
+        compute_workers = self.max_workers - 1
+        producer_interval = config.task_sleep / compute_workers
+        logger.log(TESTING_LOG_LEVEL, f'Compute workers: {compute_workers}')
+        logger.log(TESTING_LOG_LEVEL, 'Generator workers: 1')
+        logger.log(
+            TESTING_LOG_LEVEL,
+            f'Generator item interval: {producer_interval}',
+        )
+
+        stop_generator: Future[bool] = self.store.future()
+        generator_task_future = self.executor.submit(
+            generator_task,
+            store_config=self.store.config(),
+            stream_config=self.stream_config,
+            stop_generator=stop_generator,
+            item_size_bytes=config.data_size_bytes,
+            max_items=config.task_count,
+            interval=producer_interval,
+            topic=self.stream_config.topic,
+        )
+        logger.log(
+            TESTING_LOG_LEVEL,
+            'Submitted generator task: '
+            f'item_size_bytes={config.data_size_bytes}, '
+            f'max_items={config.task_count}, '
+            f'interval_seconds={producer_interval}',
+        )
+
+        completed_tasks = 0
+        running_tasks: collections.deque[Future[bytes]] = collections.deque()
+
+        start = time.time()
+
+        try:
+            for i, item in enumerate(self.consumer):
+                task_future = self.executor.submit(
+                    compute_task,
+                    item,
+                    sleep=config.task_sleep,
+                )
+                logger.log(
+                    TESTING_LOG_LEVEL,
+                    f'Submitted compute task {i}/{config.task_count}',
+                )
+                running_tasks.append(task_future)
+
+                # Only start waiting on old tasks once we've filled the
+                # available compute workers.
+                if len(running_tasks) >= compute_workers:
+                    oldest_task_future = running_tasks.popleft()
+                    oldest_task_future.result()
+                    completed_tasks += 1
+        except KeyboardInterrupt:  # pragma: no cover
+            logger.warning(
+                'Caught KeyboardInterrupt. Safely stopping generator task '
+                'and waiting on remaining compute tasks',
+            )
+            stop_generator.set_result(True)
+            generator_task_future.result()
+
+        logger.log(TESTING_LOG_LEVEL, 'Finished submitting new compute tasks')
+        logger.log(TESTING_LOG_LEVEL, 'Waiting on outstanding compute tasks')
+
+        # Wait on remaining tasks. There should be compute_workers number
+        # of tasks remaining unless a KeyboardInterrupt occurred.
+        while len(running_tasks) > 0:
+            task = running_tasks.popleft()
+            task.result()
+            completed_tasks += 1
+
+        logger.log(TESTING_LOG_LEVEL, 'All compute tasks finished')
+
+        end = time.time()
+
         assert self.stream_config.kind is not None
         return RunResult(
             executor=self.executor.__class__.__name__,
             connector=self.store.connector.__class__.__name__,
             stream=self.stream_config.kind,
             data_size_bytes=config.data_size_bytes,
-            producer_sleep=config.producer_sleep,
             task_count=config.task_count,
             task_sleep=config.task_sleep,
             workers=self.max_workers,
-            task_submitted_timestamp=0,
-            task_received_timestamp=1,
+            completed_tasks=completed_tasks,
+            start_submit_tasks_timestamp=start,
+            end_tasks_done_timestamp=end,
         )

--- a/psbench/benchmarks/stream_scaling/shims.py
+++ b/psbench/benchmarks/stream_scaling/shims.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import Self
+else:  # pragma: <3.11 cover
+    from typing_extensions import Self
+
+from proxystore.proxy import Proxy
+from proxystore.stream.interface import StreamConsumer
+from proxystore.stream.interface import StreamProducer
+
+CLOSE_SENTINAL = b'<publisher-close-topic-sentinal>'
+
+
+class ConsumerShim:
+    def __init__(
+        self,
+        consumer: StreamConsumer[bytes],
+        direct_from_subscriber: bool = False,
+    ) -> None:
+        self.consumer = consumer
+        self.direct_from_subscriber = direct_from_subscriber
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> Proxy[bytes] | bytes:
+        if self.direct_from_subscriber:
+            data = next(self.consumer._subscriber)
+            if data == CLOSE_SENTINAL:
+                raise StopIteration
+            return data
+        else:
+            return next(self.consumer)
+
+
+class ProducerShim:
+    def __init__(
+        self,
+        producer: StreamProducer[bytes],
+        direct_to_publisher: bool = False,
+        proxy_evict: bool = True,
+    ) -> None:
+        self.producer = producer
+        self.direct_to_publisher = direct_to_publisher
+        self.proxy_evict = proxy_evict
+
+    def send(self, topic: str, data: bytes) -> None:
+        if self.direct_to_publisher:
+            self.producer._publisher.send(topic, data)
+        else:
+            self.producer.send(topic, data, evict=self.proxy_evict)
+
+    def close_topic(self, topic: str) -> None:
+        if self.direct_to_publisher:
+            self.producer._publisher.send(topic, CLOSE_SENTINAL)
+        else:
+            self.producer.close_topics(topic)

--- a/psbench/executor/parsl.py
+++ b/psbench/executor/parsl.py
@@ -44,7 +44,7 @@ class ParslExecutor:
         # Mapping of function to function wrapped in Parsl App
         self._parsl_apps: dict[Callable[[Any], Any], PythonApp] = {}
 
-        self.max_workers: int | None = None
+        self.max_workers: int | None = max_workers
 
         (executor,) = config.executors
         if isinstance(executor, ThreadPoolExecutor):

--- a/psbench/run/stream_scaling.py
+++ b/psbench/run/stream_scaling.py
@@ -7,6 +7,8 @@ import sys
 from datetime import datetime
 from typing import Sequence
 
+from proxystore.stream.interface import StreamConsumer
+
 from psbench.benchmarks.stream_scaling.config import BenchmarkMatrix
 from psbench.benchmarks.stream_scaling.main import Benchmark
 from psbench.config import ExecutorConfig
@@ -56,11 +58,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     stream_config = StreamConfig.from_args(**args)
     logger.log(TESTING_LOG_LEVEL, 'All configurations loaded')
 
+    # We'll let the Benchmark object handle entering and exit these context
+    # managers.
     executor = executor_config.get_executor()
     store = store_config.get_store()
+    consumer = StreamConsumer(
+        stream_config.get_subscriber(),
+        {stream_config.topic: store},
+    )
     assert store is not None
 
-    benchmark = Benchmark(executor, store, stream_config=stream_config)
+    benchmark = Benchmark(
+        consumer,
+        executor,
+        store,
+        stream_config=stream_config,
+    )
     logger.log(TESTING_LOG_LEVEL, 'Benchmark initialized')
 
     csv_file = os.path.join(general_config.run_dir, general_config.csv_file)

--- a/psbench/run/stream_scaling.py
+++ b/psbench/run/stream_scaling.py
@@ -62,10 +62,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     # managers.
     executor = executor_config.get_executor()
     store = store_config.get_store()
-    consumer = StreamConsumer(
-        stream_config.get_subscriber(),
-        {stream_config.topic: store},
-    )
+    consumer = StreamConsumer(stream_config.get_subscriber())
     assert store is not None
 
     benchmark = Benchmark(

--- a/psbench/runner.py
+++ b/psbench/runner.py
@@ -43,7 +43,12 @@ def runner(
                 result = benchmark.run(config)
                 run_end = time.perf_counter()
 
-                result_logger.log(result)
+                results = (
+                    [result] if not isinstance(result, Sequence) else result
+                )
+                for result in results:
+                    result_logger.log(result)
+
                 logger.log(
                     TESTING_LOG_LEVEL,
                     f'Run {i+1}/{repeat} completed in {run_end - run_start} s',

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -15,13 +15,13 @@ from testing.executor import ThreadPoolExecutor
 
 @pytest.fixture()
 def process_executor() -> Generator[ProcessPoolExecutor, None, None]:
-    with ProcessPoolExecutor(2) as executor:
+    with ProcessPoolExecutor(4) as executor:
         yield executor
 
 
 @pytest.fixture()
 def thread_executor() -> Generator[ThreadPoolExecutor, None, None]:
-    with ThreadPoolExecutor(2) as executor:
+    with ThreadPoolExecutor(4) as executor:
         yield executor
 
 

--- a/testing/stream.py
+++ b/testing/stream.py
@@ -21,7 +21,7 @@ def create_stream_pair(
     None,
     None,
 ]:
-    queue_ = queue.Queue[bytes]()
+    queue_: queue.Queue[bytes] = queue.Queue()
 
     publisher = QueuePublisher({topic: queue_})
     subscriber = QueueSubscriber(queue_)

--- a/testing/stream.py
+++ b/testing/stream.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import contextlib
+import queue
+from typing import Generator
+
+from proxystore.connectors.file import FileConnector
+from proxystore.store.base import Store
+from proxystore.stream.interface import StreamConsumer
+from proxystore.stream.interface import StreamProducer
+from proxystore.stream.shims.queue import QueuePublisher
+from proxystore.stream.shims.queue import QueueSubscriber
+
+
+@contextlib.contextmanager
+def create_stream_pair(
+    store: Store[FileConnector],
+    topic: str,
+) -> Generator[
+    tuple[StreamProducer[bytes], StreamConsumer[bytes]],
+    None,
+    None,
+]:
+    queue_ = queue.Queue[bytes]()
+
+    publisher = QueuePublisher({topic: queue_})
+    subscriber = QueueSubscriber(queue_)
+
+    with StreamProducer[bytes](publisher, {topic: store}) as producer:
+        with StreamConsumer[bytes](subscriber) as consumer:
+            yield producer, consumer

--- a/tests/benchmarks/stream_scaling/config_test.py
+++ b/tests/benchmarks/stream_scaling/config_test.py
@@ -14,8 +14,6 @@ def test_benchmark_matrix_argparse() -> None:
             '1',
             '2',
             '3',
-            '--producer-sleep',
-            '4',
             '--task-count',
             '5',
             '--task-sleep',
@@ -25,7 +23,6 @@ def test_benchmark_matrix_argparse() -> None:
     matrix = BenchmarkMatrix.from_args(**vars(args))
 
     assert matrix.data_size_bytes == [1, 2, 3]
-    assert matrix.producer_sleep == 4
     assert matrix.task_count == 5
     assert matrix.task_sleep == 6
 
@@ -33,7 +30,6 @@ def test_benchmark_matrix_argparse() -> None:
 def test_benchmark_matrix_configs() -> None:
     matrix = BenchmarkMatrix(
         data_size_bytes=[1, 2, 3],
-        producer_sleep=4,
         task_count=5,
         task_sleep=6,
     )
@@ -42,6 +38,5 @@ def test_benchmark_matrix_configs() -> None:
     assert len(configs) == len(matrix.data_size_bytes)
 
     for config in configs:
-        assert config.producer_sleep == matrix.producer_sleep
         assert config.task_count == matrix.task_count
         assert config.task_sleep == matrix.task_sleep

--- a/tests/benchmarks/stream_scaling/config_test.py
+++ b/tests/benchmarks/stream_scaling/config_test.py
@@ -14,6 +14,8 @@ def test_benchmark_matrix_argparse() -> None:
             '1',
             '2',
             '3',
+            '--stream-method',
+            'default',
             '--task-count',
             '5',
             '--task-sleep',
@@ -23,6 +25,7 @@ def test_benchmark_matrix_argparse() -> None:
     matrix = BenchmarkMatrix.from_args(**vars(args))
 
     assert matrix.data_size_bytes == [1, 2, 3]
+    assert matrix.stream_method == ['default']
     assert matrix.task_count == 5
     assert matrix.task_sleep == 6
 
@@ -30,12 +33,14 @@ def test_benchmark_matrix_argparse() -> None:
 def test_benchmark_matrix_configs() -> None:
     matrix = BenchmarkMatrix(
         data_size_bytes=[1, 2, 3],
+        stream_method=['default', 'proxy'],
         task_count=5,
         task_sleep=6,
     )
 
     configs = matrix.configs()
-    assert len(configs) == len(matrix.data_size_bytes)
+    expected = len(matrix.data_size_bytes) * len(matrix.stream_method)
+    assert len(configs) == expected
 
     for config in configs:
         assert config.task_count == matrix.task_count

--- a/tests/benchmarks/stream_scaling/generator_test.py
+++ b/tests/benchmarks/stream_scaling/generator_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from unittest import mock
 
+import pytest
 from proxystore.connectors.file import FileConnector
 from proxystore.store.base import Store
 from proxystore.store.future import Future
@@ -13,7 +14,11 @@ from psbench.config.stream import StreamConfig
 from testing.stream import create_stream_pair
 
 
-def test_generator_max_items(file_store: Store[FileConnector]) -> None:
+@pytest.mark.parametrize('pregenerate', (True, False))
+def test_generator_max_items(
+    pregenerate: bool,
+    file_store: Store[FileConnector],
+) -> None:
     stop_generator: Future[bool] = file_store.future()
     item_size_bytes = 100
     max_items = 5
@@ -25,6 +30,7 @@ def test_generator_max_items(file_store: Store[FileConnector]) -> None:
             stop_generator,
             item_size_bytes=100,
             max_items=5,
+            pregenerate=pregenerate,
             interval=0,
             topic=topic,
         )

--- a/tests/benchmarks/stream_scaling/generator_test.py
+++ b/tests/benchmarks/stream_scaling/generator_test.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import contextlib
+import queue
+import time
+from typing import Generator
+from unittest import mock
+
+from proxystore.connectors.file import FileConnector
+from proxystore.store.base import Store
+from proxystore.store.future import Future
+from proxystore.stream.interface import StreamConsumer
+from proxystore.stream.interface import StreamProducer
+from proxystore.stream.shims.queue import QueuePublisher
+from proxystore.stream.shims.queue import QueueSubscriber
+
+from psbench.benchmarks.stream_scaling.generator import generate_data
+from psbench.benchmarks.stream_scaling.generator import generator_task
+from psbench.config.stream import StreamConfig
+
+
+@contextlib.contextmanager
+def create_stream_pair(
+    store: Store[FileConnector],
+    topic: str,
+) -> Generator[
+    tuple[StreamProducer[bytes], StreamConsumer[bytes]],
+    None,
+    None,
+]:
+    queue_ = queue.Queue[bytes]()
+
+    publisher = QueuePublisher({topic: queue_})
+    subscriber = QueueSubscriber(queue_)
+
+    with StreamProducer[bytes](publisher, {topic: store}) as producer:
+        with StreamConsumer[bytes](subscriber) as consumer:
+            yield producer, consumer
+
+
+def test_generator_max_items(file_store: Store[FileConnector]) -> None:
+    stop_generator: Future[bool] = file_store.future()
+    item_size_bytes = 100
+    max_items = 5
+    topic = 'topic'
+
+    with create_stream_pair(file_store, topic) as (producer, consumer):
+        generate_data(
+            producer,
+            stop_generator,
+            item_size_bytes=100,
+            max_items=5,
+            sleep=0,
+            topic=topic,
+        )
+
+        items = list(consumer.iter_objects())
+
+    assert len(items) == max_items
+    assert all(len(item) == item_size_bytes for item in items)
+
+
+def test_generator_sleep(file_store: Store[FileConnector]) -> None:
+    stop_generator: Future[bool] = file_store.future()
+    sleep = 0.01
+    topic = 'topic'
+
+    with create_stream_pair(file_store, topic) as (producer, consumer):
+        start = time.perf_counter()
+        generate_data(
+            producer,
+            stop_generator,
+            item_size_bytes=1,
+            max_items=1,
+            sleep=sleep,
+            topic=topic,
+        )
+        end = time.perf_counter()
+        assert (end - start) > sleep
+
+
+def test_generator_stop(file_store: Store[FileConnector]) -> None:
+    stop_generator: Future[bool] = file_store.future()
+    topic = 'topic'
+
+    stop_generator.set_result(True)
+
+    with create_stream_pair(file_store, topic) as (producer, consumer):
+        generate_data(
+            producer,
+            stop_generator,
+            item_size_bytes=100,
+            max_items=5,
+            sleep=0,
+            topic=topic,
+        )
+
+        items = list(consumer.iter_objects())
+
+    assert len(items) == 0
+
+
+def test_generator_task(file_store: Store[FileConnector]) -> None:
+    stop_generator: Future[bool] = file_store.future()
+    stream_config = StreamConfig(
+        kind='redis',
+        topic='topic',
+        servers=['localhost:1234'],
+    )
+
+    with mock.patch(
+        'psbench.benchmarks.stream_scaling.generator.generate_data',
+    ) as mock_generate, mock.patch('psbench.config.stream.RedisPublisher'):
+        generator_task(
+            file_store.config(),
+            stream_config,
+            stop_generator,
+            item_size_bytes=100,
+            max_items=1,
+            sleep=0,
+            topic='topic',
+        )
+
+        assert mock_generate.call_count == 1

--- a/tests/benchmarks/stream_scaling/main_test.py
+++ b/tests/benchmarks/stream_scaling/main_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 from unittest import mock
 
+import pytest
 from proxystore.connectors.file import FileConnector
 from proxystore.store.base import Store
 
@@ -13,7 +14,9 @@ from testing.executor import ThreadPoolExecutor
 from testing.stream import create_stream_pair
 
 
+@pytest.mark.parametrize('use_proxies', (True, False))
 def test_benchmark(
+    use_proxies: bool,
     file_store: Store[FileConnector],
     thread_executor: ThreadPoolExecutor,
 ) -> None:
@@ -26,6 +29,7 @@ def test_benchmark(
         data_size_bytes=100,
         task_count=8,
         task_sleep=0.001,
+        use_proxies=use_proxies,
     )
 
     with contextlib.ExitStack() as stack:

--- a/tests/run/stream_scaling_test.py
+++ b/tests/run/stream_scaling_test.py
@@ -12,6 +12,8 @@ def test_stream_scaling_main(tmp_path: pathlib.Path) -> None:
         '1',
         '2',
         '3',
+        '--stream-method',
+        'proxy',
         '--task-count',
         '5',
         '--task-sleep',
@@ -32,5 +34,7 @@ def test_stream_scaling_main(tmp_path: pathlib.Path) -> None:
         'psbench.config.StoreConfig.get_store',
     ), mock.patch(
         'psbench.config.StreamConfig.get_subscriber',
-    ), mock.patch('psbench.run.stream_scaling.StreamConsumer'):
+    ), mock.patch(
+        'psbench.run.stream_scaling.StreamConsumer',
+    ), mock.patch('psbench.run.stream_scaling.init_logging'):
         main(argv)

--- a/tests/run/stream_scaling_test.py
+++ b/tests/run/stream_scaling_test.py
@@ -12,8 +12,6 @@ def test_stream_scaling_main(tmp_path: pathlib.Path) -> None:
         '1',
         '2',
         '3',
-        '--producer-sleep',
-        '4',
         '--task-count',
         '5',
         '--task-sleep',
@@ -32,5 +30,7 @@ def test_stream_scaling_main(tmp_path: pathlib.Path) -> None:
 
     with mock.patch('psbench.run.stream_scaling.runner'), mock.patch(
         'psbench.config.StoreConfig.get_store',
-    ):
+    ), mock.patch(
+        'psbench.config.StreamConfig.get_subscriber',
+    ), mock.patch('psbench.run.stream_scaling.StreamConsumer'):
         main(argv)


### PR DESCRIPTION
<!---
    Please fill out the following template for the PR. Some parts may not
    apply to every PR type, so N/A can be used as necessary.
--->

# Description
<!--- Describe your changes in detail --->

Fills out the skeleton stream scaling benchmark added in a previous PR.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!---
    Check which off the following types describe this PR.
    These correspond to PR tags.
--->

- [ ] Breaking Change (fix or enhancement which changes existing semantics of the public interface)
- [x] Enhancement (new features or improvements to existing functionality)
- [ ] Bug (fixes for a bug or issue)
- [ ] Internal (refactoring, style changes, testing, optimizations)
- [ ] Documentation update (changes to documentation or examples)
- [ ] Package (dependencies, versions, package metadata)
- [ ] Development (CI workflows, pre-commit, linters, templates)
- [ ] Security (security related changes)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests, and tested with Parsl and a local Redis server.

Test commands:
```bash
$ redis-server --save "" --appendonly no
$ python -m psbench.run.stream_scaling --executor parsl --parsl-executor htex-local --parsl-max-workers 4 --stream-method default proxy --data-size-bytes 100000 1000000 10000000 --task-count 16 --task-sleep 1.0 --ps-connector redis --ps-host localhost --ps-port 6379 --stream redis --stream-servers localhost:6379
```

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Tags added to PR (e.g., breaking, bug, enhancement, internal, documentation, package, development, security).
- [x] Code changes pass `pre-commit` (e.g., black, mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
